### PR TITLE
docs: migrations notes and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# SQLite database
+db.sqlite3
+
+# Virtual environment
+venv/
+
+# IDE/editor directories
+.vscode/
+.idea/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Logs
+*.log
+
+# OS files
+.DS_Store
+
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # prognoz
+
+Projeto para análise de viabilidade imobiliária.
+
+## Migrations e deploy
+
+1. Gerar e commitar migrations sempre que alterar modelos:
+
+```bash
+python3 manage.py makemigrations
+git add <app>/migrations
+git commit -m "Add migration: ..."
+```
+
+2. Aplicar migrations no deploy:
+
+```bash
+python3 manage.py migrate
+```
+
+3. Pipeline CI recomendada:
+
+- `python3 manage.py showmigrations --plan`  # detecta migrations pendentes
+- `python3 manage.py migrate --noinput`
+- `python3 manage.py test`
+
+4. Arquivos a ignorar no git: `db.sqlite3`, `venv/`, `__pycache__/`, `.env`.
+
+5. Em ambientes com múltiplas instâncias, garantir que migrations rodem antes de trocar tráfego.


### PR DESCRIPTION
Adiciona instruções básicas sobre migrations e deploy; adiciona .gitignore para evitar commit de db.sqlite3, venv e __pycache__.